### PR TITLE
fix: dependencias ts-node no estaba actualizado en el pnpm-lock 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,9 +336,19 @@ importers:
       swagger-ui-express:
         specifier: ^5.0.1
         version: 5.0.1(express@4.21.2)
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
       zod:
         specifier: ^3.23.8
         version: 3.25.76
+    devDependencies:
+      nodemon:
+        specifier: ^3.1.7
+        version: 3.1.10
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.16.5)(typescript@5.8.3)
 
   services/task-service:
     dependencies:


### PR DESCRIPTION
corregido